### PR TITLE
correctly fetches name if a version > 40 was used to parse the AST

### DIFF
--- a/src/AstReverter/AstReverter.php
+++ b/src/AstReverter/AstReverter.php
@@ -645,7 +645,7 @@ class AstReverter
             $implements .= $this->revertAST($node->children['implements']);
         }
 
-        $code .= $modifier . $type . ' ' . $node->name;
+        $code .= $modifier . $type . ' ' . $this->getNodeName($node);
 
         if ($args !== null) {
             $code .= $this->revertAST($args);
@@ -670,6 +670,15 @@ class AstReverter
         $code .= $this->indent() . '}';
 
         return $code;
+    }
+
+    private function getNodeName(Node $node) : string
+    {
+        if ($node instanceof Decl) {
+            return $node->name;
+        }
+
+        return $node->children['name'];
     }
 
     private function classConst(Node $node) : string
@@ -1048,7 +1057,7 @@ class AstReverter
             $code .= '&';
         }
 
-        $code .= $node->name . $this->revertAST($node->children['params']);
+        $code .= $this->getNodeName($node) . $this->revertAST($node->children['params']);
 
         if ($node->children['returnType'] !== null) {
             $code .= ' : ' . $this->revertAST($node->children['returnType']);
@@ -1383,7 +1392,7 @@ class AstReverter
         $code .= $scope
             . ' function '
             . $returnsRef
-            . $node->name
+            . $this->getNodeName($node)
             . $this->revertAST($node->children['params']);
 
         if ($node->children['returnType'] !== null) {


### PR DESCRIPTION
after this version, Decl nodes are no longer generated.